### PR TITLE
feat: add stylelint and handlebars config to template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ vendor/bundle/
 *.js.map
 *.zip
 .idea/
-.vscode/settings.json
 assets/dist/
 parsed/
 manifest.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "files.associations": {
+    "*.html": "handlebars"
+  },
+  "stylelint.validate": [
+    "css",
+    "scss"
+  ]
+}


### PR DESCRIPTION
## Issue Info

Currently, in order to use stylelint in its latest versions, you must manually add settings in .vscode/settings.json.

Also for vscode to detect .html files as handlebars.

I propose that this configuration be part of the template for all bigcommerce projects.